### PR TITLE
Rails6.0.0以上に対応限定する

### DIFF
--- a/lib/pushing/adapters/fcm/andpush_adapter.rb
+++ b/lib/pushing/adapters/fcm/andpush_adapter.rb
@@ -1,7 +1,6 @@
 # frozen-string-literal: true
 
 require 'andpush'
-require 'active_support/core_ext/hash/transform_values'
 
 module Pushing
   module Adapters

--- a/pushing.gemspec
+++ b/pushing.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject {|f| f.match(%r{^(test)/}) }
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 2.4.0"
+
   spec.add_dependency "actionpack", ">= 4.2.0"
   spec.add_dependency "actionview", ">= 4.2.0"
   spec.add_dependency "activejob", ">= 4.2.0"


### PR DESCRIPTION
transform_valuesがRuby2.4系からデフォルトで採用された代わりに、Rails6系から除外されているのでその対応。
https://apidock.com/rails/v5.2.3/Hash/transform_values